### PR TITLE
Fix download links

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -66,19 +66,19 @@ For systems without internet access, you can download and install **Director** m
   <tr><th>Operating System</th><th>Download Link</th></tr>
   <tr>
     <td rowspan="2">Windows</td>
-    <td><a href="https://dl.vget.me/windows/amd64/vmetric-director.exe">AMD64</a></td>
+    <td><a href="https://dl.vget.me/director/windows/amd64/vmetric-director.exe">AMD64</a></td>
   </tr>
-  <tr><td><a href="https://dl.vget.me/windows/arm64/vmetric-director.exe">ARM64</a></td></tr>
+  <tr><td><a href="https://dl.vget.me/director/windows/arm64/vmetric-director.exe">ARM64</a></td></tr>
   <tr>
     <td rowspan="2">Linux</td>
-    <td><a href="https://dl.vget.me/linux/amd64/vmetric-director">AMD64</a></td>
+    <td><a href="https://dl.vget.me/director/linux/amd64/vmetric-director">AMD64</a></td>
   </tr>
-  <tr><td><a href="https://dl.vget.me/linux/arm64/vmetric-director">ARM64</a></td></tr>
+  <tr><td><a href="https://dl.vget.me/director/linux/arm64/vmetric-director">ARM64</a></td></tr>
   <tr>
     <td rowspan="2">macOS</td>
-    <td><a href="https://dl.vget.me/darwin/amd64/vmetric-director">AMD64</a></td>
+    <td><a href="https://dl.vget.me/director/darwin/amd64/vmetric-director">AMD64</a></td>
   </tr>
-  <tr><td><a href="https://dl.vget.me/darwin/arm64/vmetric-director">ARM64</a></td></tr>
+  <tr><td><a href="https://dl.vget.me/director/darwin/arm64/vmetric-director">ARM64</a></td></tr>
 </table>
 
 Once you have downloaded the binary, open a terminal as _Administrator_ on **Windows**, as _sudo_ on **Linux**, or as _root_ on **macOS**.


### PR DESCRIPTION
This pull request includes changes to the download links in the `docs/getting-started.mdx` file to ensure they point to the correct directories for the **Director** software.

* Updated download links for Windows, Linux, and macOS to include the correct directory path (`/director/`) for both AMD64 and ARM64 architectures.